### PR TITLE
Update typings to work with the latest @types/{react,react-dom} packages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,4 +22,4 @@ interface QRCodeProps {
 /**
  * The component
  */
-export function QRCode(props: QRCodeProps & React.SVGProps): React.ReactElement<{}>;
+export function QRCode(props: QRCodeProps & React.SVGProps<SVGElement>): React.ReactElement<{}>;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "qr.js": "0.0.0"
   },
   "devDependencies": {
+    "@types/react": "^15.6.0",
+    "@types/react-dom": "^15.5.1",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",
     "babel-eslint": "^7.2.3",

--- a/tests/typescript/index.tsx
+++ b/tests/typescript/index.tsx
@@ -5,8 +5,8 @@ interface IDemoProps {
     text: string;
 }
 
-class Demo extends React.Component<IDemoProps, {}> {
-    render(): React.ReactElement<{}> {
+class Demo extends React.Component<IDemoProps> {
+    render(): JSX.Element {
         return <div>
             <QRCode bgColor="#FFFFFF" fgColor="#000000" level="M" value={this.props.text} />
             <QRCode value="Only value here" />

--- a/tests/typescript/tsconfig.json
+++ b/tests/typescript/tsconfig.json
@@ -1,7 +1,11 @@
 {
     "compilerOptions": {
         "jsx": "react",
-        "outDir": "out"
+        "outDir": "out",
+        "typeRoots": [
+          "../../node_modules/@types/",
+          "./typings/modules/"
+        ]
     },
     "exclude": [
         "node_modules"

--- a/tests/typescript/typings.json
+++ b/tests/typescript/typings.json
@@ -1,7 +1,5 @@
 {
   "dependencies": {
-    "react": "registry:npm/react#15.0.1+20170104200836",
-    "react-dom": "registry:npm/react-dom#15.0.1+20160826174104",
     "react-qr-svg": "file:../../index.d.ts"
   }
 }


### PR DESCRIPTION
Typings were updated and the test process improved to catch this type of error in the future.

Closes #57

