### PR TITLE
build: re-add rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-dom": "~15.6.1",
     "react-ghfork": "^0.3.3",
     "react-test-renderer": "~15.6.1",
+    "rimraf": "^2.6.1",
     "semantic-release": "^7.0.1",
     "style-loader": "^0.18.1",
     "url-loader": "^0.5.7",


### PR DESCRIPTION
The `rimraf` package was errorneously removed which breaks the build.