### PR TITLE
Support for React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "webpack-merge": "^4.0.0"
   },
   "peerDependencies": {
-    "react": ">= 0.11.2 < 16.0.0"
+    "react": ">= 0.11.2 < 17.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/components/qr-svg.js
+++ b/src/components/qr-svg.js
@@ -18,11 +18,14 @@ export function QRCode({
 
     const cells = qrcode.modules;
 
+    let cellIndex = 0; // we use simple order as a key just to avoid the key warning here
+
     return (<svg shapeRendering="crispEdges" viewBox={[0, 0, cells.length, cells.length].join(' ')} {...otherProps}>
         {
             cells.map((row, rowIndex) =>
                 row.map((cell, colIndex) => (
                     <rect height={1}
+                        key={cellIndex++} // string was too slow here
                         style={{ fill: cell ? fgColor : bgColor }}
                         width={1}
                         x={colIndex}


### PR DESCRIPTION
This adds the most simplistic support for React 16. The `peerDependency` spec was bumped and the missing key warning was resolved.

Closes #88