### PR TITLE
added cell classnames

### DIFF
--- a/src/components/qr-svg.js
+++ b/src/components/qr-svg.js
@@ -29,6 +29,11 @@ export function QRCode({
             {cells.map((row, rowIndex) =>
                 row.map((cell, colIndex) => (
                     <rect
+                        className={
+                            cell
+                                ? "qr-svg-cell qr-svg-cell-filled"
+                                : "qr-svg-cell qr-svg-cell-empty"
+                        }
                         height={1}
                         key={cellIndex++} // string was too slow here
                         style={{ fill: cell ? fgColor : bgColor }}


### PR DESCRIPTION
This allows me to set the filled and empty cell colours through my stylesheet, and works with Content-Security-Policy `style-src 'self'`, so I don't have to use `style-src 'unsafe-inline'`.

Solves #136 